### PR TITLE
Support for multiple relay cards (command line interface only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+src/crelay

--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ The following picture shows a high level view on the modular software architectu
 - HTTP API for external clients (e.g. Smartphone/tablet apps)
 - Multiple relay card type support  
 - Support for configuration file with custom parameters
+- Multiple cards support (command line interface only)
 <br>
 
 ### Nice to have (wishlist)
 - Integrated MQTT client
 - [ThingSpeak Talkback App](https://thingspeak.com/docs/talkback)
-- Multiple cards support
+- Multiple cards support (Web UI)
 - Access control for Web GUI and HTTP API
 - Programmable timers for relay actions  
 <br>
@@ -70,19 +71,19 @@ The following picture shows a high level view on the modular software architectu
       - Sainsmart USB 4-channel relay card
       - HID API compatible relay card
       - Generic GPIO relays
-    The card which is detected first will be used. 
+    The card which is detected first will be used, unless -s switch and a serial number is passed.
     
     The program can be run in interactive (command line) mode or in daemon mode with
     built-in web server.
 
     Interactive mode:
-        crelay -i | [<relay number>] [ON|OFF]
+        crelay [-s <serial number>] -i | [<relay number>] [ON|OFF]
 
            The state of any relay can be read or it can be changed to a new state.
            If only the relay number is provided then the current state is returned,
            otherwise the relays state is set to the new value provided as second parameter.
            The USB communication port is auto detected. The first compatible device
-           found will be used.
+           found will be used, unless -s switch and a serial number is passed.
 
     Daemon mode:
         crelay -d [<relay1_label> [<relay2_label> [<relay3_label> [<relay4_label>]]]] 

--- a/src/crelay.c
+++ b/src/crelay.c
@@ -556,7 +556,7 @@ void print_usage()
    printf("       If only the relay number is provided then the current state is returned,\n");
    printf("       otherwise the relays state is set to the new value provided as second parameter.\n");
    printf("       The USB communication port is auto detected. The first compatible device\n");
-   printf("       found will be used.\n\n");
+   printf("       found will be used, unless -s switch and a serial number is passed.\n\n");
    printf("Daemon mode:\n");
    printf("    crelay -d [<relay1_label> [<relay2_label> [<relay3_label> [<relay4_label>]]]] \n\n");
    printf("       In daemon mode the built-in web server will be started and the relays\n");

--- a/src/relay_drv.c
+++ b/src/relay_drv.c
@@ -108,13 +108,13 @@ static relay_data_t relay_data[LAST_RELAY_TYPE] =
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card(char* portname, uint8* num_relays)
+int detect_relay_card(char* portname, uint8* num_relays, char* serial)
 {
    int i;
    
    for (i=1; i<LAST_RELAY_TYPE; i++)
    {
-      if ((*relay_data[i].detect_relay_card_fun)(portname, num_relays) == 0)
+      if ((*relay_data[i].detect_relay_card_fun)(portname, num_relays, serial) == 0)
       {
          relay_type=i;
          return 0;
@@ -138,11 +138,11 @@ int detect_relay_card(char* portname, uint8* num_relays)
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay(char* portname, uint8 relay, relay_state_t* relay_state)
+int get_relay(char* portname, uint8 relay, relay_state_t* relay_state, char* serial)
 {
    if (relay_type != NO_RELAY_TYPE)
    {
-      return (*relay_data[relay_type].get_relay_fun)(portname, relay, relay_state);
+      return (*relay_data[relay_type].get_relay_fun)(portname, relay, relay_state, serial);
    }
    else
    {   
@@ -163,11 +163,11 @@ int get_relay(char* portname, uint8 relay, relay_state_t* relay_state)
  * Return:   o - success
  *          -1 - fail
  *********************************************************/
-int set_relay(char* portname, uint8 relay, relay_state_t relay_state)
+int set_relay(char* portname, uint8 relay, relay_state_t relay_state, char* serial)
 {
    if (relay_type != NO_RELAY_TYPE)
    {
-      return (*relay_data[relay_type].set_relay_fun)(portname, relay, relay_state);
+      return (*relay_data[relay_type].set_relay_fun)(portname, relay, relay_state, serial);
    }
    else
    {   

--- a/src/relay_drv.h
+++ b/src/relay_drv.h
@@ -87,10 +87,10 @@ relay_state_t;
 
 typedef struct
 {
-   int (*detect_relay_card_fun)(char*, uint8*);        /* function to detect the relay card */
-   int (*get_relay_fun)(char*, uint8, relay_state_t*); /* function to get the current relay state */
-   int (*set_relay_fun)(char*, uint8, relay_state_t);  /* function to set the new relay state */
-   char *card_name;                                    /* card name string */
+   int (*detect_relay_card_fun)(char*, uint8*, char*);        /* function to detect the relay card */
+   int (*get_relay_fun)(char*, uint8, relay_state_t*, char*); /* function to get the current relay state */
+   int (*set_relay_fun)(char*, uint8, relay_state_t, char*);  /* function to set the new relay state */
+   char *card_name;                                           /* card name string */
 }
 relay_data_t;
 
@@ -110,7 +110,7 @@ relay_data_t;
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card(char* portname, uint8* num_relays);
+int detect_relay_card(char* portname, uint8* num_relays, char* serial);
 
 /**********************************************************
  * Function get_relay()
@@ -124,7 +124,7 @@ int detect_relay_card(char* portname, uint8* num_relays);
  * Return:   o - success
  *          -1 - fail
  *********************************************************/
-int get_relay(char* portname, uint8 relay, relay_state_t* relay_state);
+int get_relay(char* portname, uint8 relay, relay_state_t* relay_state, char* serial);
 
 /**********************************************************
  * Function set_relay()
@@ -138,7 +138,7 @@ int get_relay(char* portname, uint8 relay, relay_state_t* relay_state);
  * Return:   o - success
  *          -1 - fail
  *********************************************************/
-int set_relay(char* portname, uint8 relay, relay_state_t relay_state);
+int set_relay(char* portname, uint8 relay, relay_state_t relay_state, char* serial);
 
 /**********************************************************
  * Function get_relay_card_type()

--- a/src/relay_drv_conrad.c
+++ b/src/relay_drv_conrad.c
@@ -120,7 +120,7 @@ static libusb_device *device;
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_conrad_4chan(char* portname, uint8* num_relays)
+int detect_relay_card_conrad_4chan(char* portname, uint8* num_relays, char* serial)
 {
    struct libusb_device_handle *dev = NULL; 
    struct libusb_device_descriptor devdesc;
@@ -180,7 +180,7 @@ int detect_relay_card_conrad_4chan(char* portname, uint8* num_relays)
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t* relay_state)
+int get_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t* relay_state, char* serial)
 {
    struct libusb_device_handle *dev = NULL; 
    int r;  
@@ -245,7 +245,7 @@ int get_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t* relay_sta
  * Return:   o - success
  *          -1 - fail
  *********************************************************/
-int set_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t relay_state)
+int set_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t relay_state, char* serial)
 {
    struct libusb_device_handle *dev = NULL; 
    int r;  

--- a/src/relay_drv_conrad.h
+++ b/src/relay_drv_conrad.h
@@ -47,7 +47,7 @@
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_conrad_4chan(char* portname, uint8* num_relays);
+int detect_relay_card_conrad_4chan(char* portname, uint8* num_relays, char* serial);
 
 /**********************************************************
  * Function get_relay_conrad_4chan()
@@ -61,7 +61,7 @@ int detect_relay_card_conrad_4chan(char* portname, uint8* num_relays);
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t* relay_state);
+int get_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t* relay_state, char* serial);
 
 /**********************************************************
  * Function set_relay_conrad_4chan()
@@ -72,9 +72,9 @@ int get_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t* relay_sta
  *             relay (in)        - relay number
  *             relay_state (in)  - current relay state
  * 
- * Return:   o - success
+ * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int set_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t relay_state);
+int set_relay_conrad_4chan(char* portname, uint8 relay, relay_state_t relay_state, char* serial);
 
 #endif

--- a/src/relay_drv_gpio.c
+++ b/src/relay_drv_gpio.c
@@ -186,7 +186,7 @@ static int do_unexport(uint8 pin)
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_generic_gpio(char* portname, uint8* num_relays)
+int detect_relay_card_generic_gpio(char* portname, uint8* num_relays, char* serial)
 {
    int fd;
    int i;
@@ -241,7 +241,7 @@ int detect_relay_card_generic_gpio(char* portname, uint8* num_relays)
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay_generic_gpio(char* portname, uint8 relay, relay_state_t* relay_state)
+int get_relay_generic_gpio(char* portname, uint8 relay, relay_state_t* relay_state, char* serial)
 {
    int fd;
    char b[64];
@@ -304,7 +304,7 @@ int get_relay_generic_gpio(char* portname, uint8 relay, relay_state_t* relay_sta
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int set_relay_generic_gpio(char* portname, uint8 relay, relay_state_t relay_state)
+int set_relay_generic_gpio(char* portname, uint8 relay, relay_state_t relay_state, char* serial)
 {
    int fd;
    char b[64];

--- a/src/relay_drv_gpio.h
+++ b/src/relay_drv_gpio.h
@@ -47,7 +47,7 @@
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_generic_gpio(char* portname, uint8* num_relays);
+int detect_relay_card_generic_gpio(char* portname, uint8* num_relays, char* serial);
 
 /**********************************************************
  * Function get_relay_generic_gpio()
@@ -61,7 +61,7 @@ int detect_relay_card_generic_gpio(char* portname, uint8* num_relays);
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay_generic_gpio(char* portname, uint8 relay, relay_state_t* relay_state);
+int get_relay_generic_gpio(char* portname, uint8 relay, relay_state_t* relay_state, char* serial);
 
 /**********************************************************
  * Function set_relay_generic_gpio()
@@ -75,6 +75,6 @@ int get_relay_generic_gpio(char* portname, uint8 relay, relay_state_t* relay_sta
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int set_relay_generic_gpio(char* portname, uint8 relay, relay_state_t relay_state);
+int set_relay_generic_gpio(char* portname, uint8 relay, relay_state_t relay_state, char* serial);
 
 #endif

--- a/src/relay_drv_hidapi.c
+++ b/src/relay_drv_hidapi.c
@@ -122,7 +122,7 @@ static uint8 g_num_relays=HID_API_NUM_RELAYS;
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_hidapi(char* portname, uint8* num_relays)
+int detect_relay_card_hidapi(char* portname, uint8* num_relays, char* serial)
 {
    struct hid_device_info *devs;
    uint8 num;
@@ -168,7 +168,7 @@ int detect_relay_card_hidapi(char* portname, uint8* num_relays)
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay_hidapi(char* portname, uint8 relay, relay_state_t* relay_state)
+int get_relay_hidapi(char* portname, uint8 relay, relay_state_t* relay_state, char* serial)
 {
    hid_device *hid_dev;
    unsigned char buf[REPORT_LEN];  
@@ -215,7 +215,7 @@ int get_relay_hidapi(char* portname, uint8 relay, relay_state_t* relay_state)
  * Return:   o - success
  *          -1 - fail
  *********************************************************/
-int set_relay_hidapi(char* portname, uint8 relay, relay_state_t relay_state)
+int set_relay_hidapi(char* portname, uint8 relay, relay_state_t relay_state, char* serial)
 { 
    hid_device *hid_dev;
    unsigned char buf[REPORT_LEN];  

--- a/src/relay_drv_hidapi.h
+++ b/src/relay_drv_hidapi.h
@@ -47,7 +47,7 @@
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_hidapi(char* portname, uint8* num_relays);
+int detect_relay_card_hidapi(char* portname, uint8* num_relays, char* serial);
 
 
 /**********************************************************
@@ -62,7 +62,7 @@ int detect_relay_card_hidapi(char* portname, uint8* num_relays);
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay_hidapi(char* portname, uint8 relay, relay_state_t* relay_state);
+int get_relay_hidapi(char* portname, uint8 relay, relay_state_t* relay_state, char* serial);
 
 
 /**********************************************************
@@ -74,9 +74,9 @@ int get_relay_hidapi(char* portname, uint8 relay, relay_state_t* relay_state);
  *             relay (in)        - relay number
  *             relay_state (in)  - current relay state
  * 
- * Return:   o - success
+ * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int set_relay_hidapi(char* portname, uint8 relay, relay_state_t relay_state);
+int set_relay_hidapi(char* portname, uint8 relay, relay_state_t relay_state, char* serial);
 
 #endif

--- a/src/relay_drv_sainsmart.c
+++ b/src/relay_drv_sainsmart.c
@@ -97,7 +97,7 @@ extern config_t config;
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_sainsmart_4_8chan(char* portname, uint8* num_relays)
+int detect_relay_card_sainsmart_4_8chan(char* portname, uint8* num_relays, char* serial)
 {
    unsigned int chipid;
    
@@ -108,7 +108,7 @@ int detect_relay_card_sainsmart_4_8chan(char* portname, uint8* num_relays)
    }
 
    /* Try to open FTDI USB device */
-   if ((ftdi_usb_open(ftdi, VENDOR_ID, DEVICE_ID)) < 0)
+   if ((ftdi_usb_open_desc(ftdi, VENDOR_ID, DEVICE_ID, NULL, serial)) < 0)
    {
       ftdi_free(ftdi);
       return -1;
@@ -161,7 +161,7 @@ int detect_relay_card_sainsmart_4_8chan(char* portname, uint8* num_relays)
  * Return:    0 - success
  *          < 0 - fail
  *********************************************************/
-int get_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t* relay_state)
+int get_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t* relay_state, char* serial)
 {
    unsigned char buf[1];
    
@@ -172,7 +172,7 @@ int get_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t* rela
    }
 
    /* Open FTDI USB device */
-   if ((ftdi_usb_open(ftdi, VENDOR_ID, DEVICE_ID)) < 0)
+   if ((ftdi_usb_open_desc(ftdi, VENDOR_ID, DEVICE_ID, NULL, serial)) < 0)
    {
       fprintf(stderr, "unable to open ftdi device: (%s)\n", ftdi_get_error_string(ftdi));
       ftdi_free(ftdi);
@@ -206,7 +206,7 @@ int get_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t* rela
  * Return:    0 - success
  *          < 0 - fail
  *********************************************************/
-int set_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t relay_state)
+int set_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t relay_state, char* serial)
 {
    unsigned char buf[1];
    
@@ -217,7 +217,7 @@ int set_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t relay
    }
    
    /* Open FTDI USB device */
-   if ((ftdi_usb_open(ftdi, VENDOR_ID, DEVICE_ID)) < 0)
+   if ((ftdi_usb_open_desc(ftdi, VENDOR_ID, DEVICE_ID, NULL, serial)) < 0)
    {
       fprintf(stderr, "unable to open ftdi device: (%s)\n", ftdi_get_error_string(ftdi));
       ftdi_free(ftdi);

--- a/src/relay_drv_sainsmart.h
+++ b/src/relay_drv_sainsmart.h
@@ -47,7 +47,7 @@
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_sainsmart_4_8chan(char* portname, uint8* num_relays);
+int detect_relay_card_sainsmart_4_8chan(char* portname, uint8* num_relays, char* serial);
 
 /**********************************************************
  * Function get_relay_sainsmart_4_8chan()
@@ -61,7 +61,7 @@ int detect_relay_card_sainsmart_4_8chan(char* portname, uint8* num_relays);
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t* relay_state);
+int get_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t* relay_state, char* serial);
 
 /**********************************************************
  * Function set_relay_sainsmart_4_8chan()
@@ -72,9 +72,9 @@ int get_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t* rela
  *             relay (in)        - relay number
  *             relay_state (in)  - current relay state
  * 
- * Return:   o - success
+ * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int set_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t relay_state);
+int set_relay_sainsmart_4_8chan(char* portname, uint8 relay, relay_state_t relay_state, char* serial);
 
 #endif

--- a/src/relay_drv_sample.c
+++ b/src/relay_drv_sample.c
@@ -62,7 +62,7 @@
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_sample(char* portname, uint8* num_relays)
+int detect_relay_card_sample(char* portname, uint8* num_relays, char* serial)
 {
    return 0;
 }
@@ -80,7 +80,7 @@ int detect_relay_card_sample(char* portname, uint8* num_relays)
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay_sample(char* portname, uint8 relay, relay_state_t* relay_state)
+int get_relay_sample(char* portname, uint8 relay, relay_state_t* relay_state, char* serial)
 {
    return 0;
 }
@@ -98,7 +98,7 @@ int get_relay_sample(char* portname, uint8 relay, relay_state_t* relay_state)
  * Return:   o - success
  *          -1 - fail
  *********************************************************/
-int set_relay_sample(char* portname, uint8 relay, relay_state_t relay_state)
+int set_relay_sample(char* portname, uint8 relay, relay_state_t relay_state, char* serial)
 { 
    return 0;
 }

--- a/src/relay_drv_sample.h
+++ b/src/relay_drv_sample.h
@@ -48,7 +48,7 @@
  * Return:  0 - success
  *         -1 - fail, no relay card found
  *********************************************************/
-int detect_relay_card_sample(char* portname, uint8* num_relays)
+int detect_relay_card_sample(char* portname, uint8* num_relays, char* serial)
 
 
 /**********************************************************
@@ -63,7 +63,7 @@ int detect_relay_card_sample(char* portname, uint8* num_relays)
  * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int get_relay_sample(char* portname, uint8 relay, relay_state_t* relay_state);
+int get_relay_sample(char* portname, uint8 relay, relay_state_t* relay_state, char* serial);
 
 
 /**********************************************************
@@ -75,9 +75,9 @@ int get_relay_sample(char* portname, uint8 relay, relay_state_t* relay_state);
  *             relay (in)        - relay number
  *             relay_state (in)  - current relay state
  * 
- * Return:   o - success
+ * Return:   0 - success
  *          -1 - fail
  *********************************************************/
-int set_relay_sample(char* portname, uint8 relay, relay_state_t relay_state);
+int set_relay_sample(char* portname, uint8 relay, relay_state_t relay_state, char* serial);
 
 #endif


### PR DESCRIPTION
I've added a new optional switch **-s <serial number>** that can be used to specify which relay card one wants to control. The code supporting Web UI has been updated too but it has no effect since serial variable is set to NULL there.
