### PR TITLE
add error message if ftdi_usb_open fails in detect_relay_card_sainsmart_4_8chan

### DIFF
--- a/src/relay_drv_sainsmart.c
+++ b/src/relay_drv_sainsmart.c
@@ -110,6 +110,7 @@ int detect_relay_card_sainsmart_4_8chan(char* portname, uint8* num_relays)
    /* Try to open FTDI USB device */
    if ((ftdi_usb_open(ftdi, VENDOR_ID, DEVICE_ID)) < 0)
    {
+      fprintf(stderr, "unable to open FTDI USB device: (%s)\n", ftdi_get_error_string(ftdi));
       ftdi_free(ftdi);
       return -1;
    }


### PR DESCRIPTION
Other errors are logged to stderr if there are failures when detecting the relay card, but no error message is printed if opening the usb device fails.
