### PR TITLE
Sainsmart16 Bugfix: properly report on relay status

### DIFF
--- a/src/relay_drv_sainsmart16.c
+++ b/src/relay_drv_sainsmart16.c
@@ -313,7 +313,7 @@ int get_relay_sainsmart_16chan(char* portname, uint8_t relay, relay_state_t* rel
       return -3;
    }
    
-   bit = 1 << relay;
+   bit = 1 << (relay-1);
    if (bitmap & bit)
      *relay_state = ON;
    else


### PR DESCRIPTION
There's an off-by-one issue.  When asking about relay 1 we get the information for "relay 2", and when asking about relay 2 we get the information for relay 3, and so on..  This fixes that issue.